### PR TITLE
Add set -e so failed installation will abort deploys

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # bin/compile BUILD_DIR CACHE_DIR ENV_DIR
 
+set -e # fail fast
+
 arrow() {
   sed -u 's/^/-----> /'
 }


### PR DESCRIPTION
Occasionally the buildpack fails to install and the deploy continues. The suggested change ensures that a failed installation will abort the deploy.

Failed buildpack installation:
```
=====> Downloading Buildpack: https://github.com/erhhung/heroku-buildpack-exiftool
=====> Detected Framework: exiftool
-----> Installing exiftool 10.40
       Fetching   http://owl.phy.queensu.ca/~phil/exiftool/Image-ExifTool-10.40.tar.gz
gzip: stdin: unexpected end of file
tar: Child returned status 1
tar: Error is not recoverable: exiting now
mv: cannot stat ‘Image-ExifTool-10.40’: No such file or directory
/tmp/buildpackjGUPI/bin/compile: line 41: cd: ./exiftool: No such file or directory
ls: cannot access exif*: No such file or directory
       Installed: 
```

Successful buildpack installation:
```
=====> Downloading Buildpack: https://github.com/erhhung/heroku-buildpack-exiftool
=====> Detected Framework: exiftool
-----> Installing exiftool 10.40
       Fetching   http://owl.phy.queensu.ca/~phil/exiftool/Image-ExifTool-10.40.tar.gz
       Installed: exiftool
```
